### PR TITLE
DEV-279 [FIX] Changes 'List repeater' to 'Data list'

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -232,7 +232,7 @@ Fliplet.Widget.instance({
           });
         }
 
-        Fliplet.UI.Toast('Please add List Repeater component');
+        Fliplet.UI.Toast('Please add Data list component');
 
         return Promise.reject('');
       }
@@ -291,7 +291,7 @@ Fliplet.Widget.instance({
           });
         }
 
-        Fliplet.UI.Toast('Please add List Repeater component');
+        Fliplet.UI.Toast('Please add Data list component');
 
         return Promise.reject('');
       }


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Search and Filter

### What does this PR do?

Changes 'List repeater' to 'Data list'

### JIRA ticket

[DEV-279](https://weboo.atlassian.net/browse/DEV-279 )


[DEV-279]: https://weboo.atlassian.net/browse/DEV-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error messages to refer to "Data list component" instead of "List Repeater component" in relevant notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->